### PR TITLE
[Feat] Docker Setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ __pycache__/
 *.pyc
 .env
 outputs/
+output/
 data/

--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@ __pycache__/
 *.pyc
 .env
 outputs/
-output/
 data/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,48 @@ bash scripts/install_habitat.sh
 > sudo apt install libgl1-mesa-dev libglu1-mesa-dev freeglut3-dev zlib1g-dev
 >```
 
+### 🐳 Docker Setup
+As an alternative to Conda, you can also build an environment with Docker. Instead of steps 2 and 3 above you can build a Docker image using the provided compose file:
+
+```bash
+docker compose -f docker/compose.yml build
+```
+
+this will build an image called ```habitat-data-collector``` that has Cuda support and installs ```habitat-sim``` as well as ```habitat-lab``` from source.
+
+Once the build has completed you can launch a container with the same compose file:
+
+```bash
+docker compose -f docker/compose.yml up -d
+```
+
+and open an interactive shell:
+
+```bash
+docker exec -it <name-of-container> bash
+```
+
+### 🐳 Docker + 🐢 ROS2 Setup
+If you also want to use the ROS2 functionalities of this repo while running everything in Docker, there is an additional Dockerfile that builds ROS humble on top of the Docker image outlined above. The setup process is similar:
+
+Build the image:
+
+```bash
+docker compose -f docker/compose.humble.yml build
+```
+
+Start a container:
+
+```bash
+docker compose -f docker/compose.humble.yml up -d
+```
+
+and open an interactive shell:
+
+```bash
+docker exec -it <name-of-container> bash
+```
+
 
 ## 📦 Dataset Setup
 

--- a/config/habitat_data_collector.yaml
+++ b/config/habitat_data_collector.yaml
@@ -2,9 +2,9 @@ defaults:
   - _self_
 
 # Scene Output Settings
-dataset_name: hm3d
-output_path: /home/eku/workspace/hiemap/data
-scene_name: 00829-QaLdnwvtxbs
+dataset_name: mp3d
+output_path: /app/output
+scene_name: 17DRP5sb8fy
 
 # Habitat Setting
 # temp
@@ -17,12 +17,12 @@ load_from_config: false
 scene_config: /home/eku/workspace/dataset/HM3D_collect/00829-QaLdnwvtxbs/dynamic_scene_config/0117.json
 
 # HM3D
-scene_path: /home/eku/workspace/dataset/HM3D/val/00829-QaLdnwvtxbs/QaLdnwvtxbs.basis.glb
-scene_dataset_config: /home/eku/workspace/dataset/HM3D/val/hm3d_annotated_basis.scene_dataset_config.json
+# scene_path: /home/eku/workspace/dataset/HM3D/val/00829-QaLdnwvtxbs/QaLdnwvtxbs.basis.glb
+# scene_dataset_config: /home/eku/workspace/dataset/HM3D/val/hm3d_annotated_basis.scene_dataset_config.json
 
 # MP3D
-# scene_path: /home/eku/workspace/habitat-sim/data/mp3d_example/17DRP5sb8fy/17DRP5sb8fy.glb
-# scene_dataset_config: /home/eku/workspace/habitat-sim/data/mp3d_example/mp3d.scene_dataset_config.json
+scene_path: /app/data/scene_datasets/mp3d/17DRP5sb8fy/17DRP5sb8fy.glb
+scene_dataset_config: /app/data/scene_datasets/mp3d/mp3d.scene_dataset_config.json
 
 # Replica
 # scene_path: /home/eku/workspace/dataset/Replica-Dataset/Replica_original/room_0/habitat/mesh_semantic.ply
@@ -30,7 +30,7 @@ scene_dataset_config: /home/eku/workspace/dataset/HM3D/val/hm3d_annotated_basis.
 
 
 # Object Path
-objects_path: /home/eku/workspace/dataset/objects/new_objects
+objects_path: /app/data/objects/new_objects
 
 # Sensor and Camera Settings
 data_cfg:

--- a/config/habitat_data_collector.yaml
+++ b/config/habitat_data_collector.yaml
@@ -2,9 +2,9 @@ defaults:
   - _self_
 
 # Scene Output Settings
-dataset_name: mp3d
-output_path: /app/output
-scene_name: 17DRP5sb8fy
+dataset_name: hm3d
+output_path: /home/eku/workspace/hiemap/data
+scene_name: 00829-QaLdnwvtxbs
 
 # Habitat Setting
 # temp
@@ -17,12 +17,12 @@ load_from_config: false
 scene_config: /home/eku/workspace/dataset/HM3D_collect/00829-QaLdnwvtxbs/dynamic_scene_config/0117.json
 
 # HM3D
-# scene_path: /home/eku/workspace/dataset/HM3D/val/00829-QaLdnwvtxbs/QaLdnwvtxbs.basis.glb
-# scene_dataset_config: /home/eku/workspace/dataset/HM3D/val/hm3d_annotated_basis.scene_dataset_config.json
+scene_path: /home/eku/workspace/dataset/HM3D/val/00829-QaLdnwvtxbs/QaLdnwvtxbs.basis.glb
+scene_dataset_config: /home/eku/workspace/dataset/HM3D/val/hm3d_annotated_basis.scene_dataset_config.json
 
 # MP3D
-scene_path: /app/data/scene_datasets/mp3d/17DRP5sb8fy/17DRP5sb8fy.glb
-scene_dataset_config: /app/data/scene_datasets/mp3d/mp3d.scene_dataset_config.json
+# scene_path: /home/eku/workspace/habitat-sim/data/mp3d_example/17DRP5sb8fy/17DRP5sb8fy.glb
+# scene_dataset_config: /home/eku/workspace/habitat-sim/data/mp3d_example/mp3d.scene_dataset_config.json
 
 # Replica
 # scene_path: /home/eku/workspace/dataset/Replica-Dataset/Replica_original/room_0/habitat/mesh_semantic.ply
@@ -30,7 +30,7 @@ scene_dataset_config: /app/data/scene_datasets/mp3d/mp3d.scene_dataset_config.js
 
 
 # Object Path
-objects_path: /app/data/objects/new_objects
+objects_path: /home/eku/workspace/dataset/objects/new_objects
 
 # Sensor and Camera Settings
 data_cfg:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && \
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 
 # Install Habitat-Sim
-RUN git clone --branch v0.3,3 https://github.com/facebookresearch/habitat-sim.git
+RUN git clone --branch v0.3.2 https://github.com/facebookresearch/habitat-sim.git
 WORKDIR /habitat-sim
 
 # Patch dependencies.cmake to force MAGNUM_TARGET_EGL to OFF
@@ -69,11 +69,13 @@ RUN CMAKE_ARGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DTARGET_HEADLESS=ON" pip ins
 
 # Install Habitat-Lab
 WORKDIR /
-RUN git clone --branch v0.3.3 https://github.com/facebookresearch/habitat-lab.git
+RUN git clone --branch v0.3.2 https://github.com/facebookresearch/habitat-lab.git
 WORKDIR /habitat-lab
 RUN pip install -e habitat-lab
 RUN pip install pybullet==3.0.4 pygame==2.1.2
 
+# Create symlink so 'python' points to 'python3'
+RUN ln -sf /usr/bin/python3 /usr/bin/python
 
 WORKDIR /app
 CMD ["/bin/bash"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,7 @@ RUN apt-get update && \
 RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
 
 # Install Habitat-Sim
-RUN git clone https://github.com/facebookresearch/habitat-sim.git
+RUN git clone --branch v0.3,3 https://github.com/facebookresearch/habitat-sim.git
 WORKDIR /habitat-sim
 
 # Patch dependencies.cmake to force MAGNUM_TARGET_EGL to OFF
@@ -69,7 +69,7 @@ RUN CMAKE_ARGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DTARGET_HEADLESS=ON" pip ins
 
 # Install Habitat-Lab
 WORKDIR /
-RUN git clone https://github.com/facebookresearch/habitat-lab.git
+RUN git clone --branch v0.3.3 https://github.com/facebookresearch/habitat-lab.git
 WORKDIR /habitat-lab
 RUN pip install -e habitat-lab
 RUN pip install pybullet==3.0.4 pygame==2.1.2

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,79 @@
+FROM nvidia/cuda:12.9.1-devel-ubuntu22.04
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install system dependencies
+# Added ninja-build for faster builds
+RUN apt-get update && apt-get install -y \
+    git \
+    git-lfs \
+    curl \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libglvnd-dev \
+    libgl1-mesa-glx \
+    libegl1-mesa \
+    freeglut3-dev \
+    zlib1g-dev \
+    x11-apps \
+    cmake \
+    xvfb \
+    build-essential \
+    libx11-dev \
+    libxcursor-dev \
+    libxi-dev \
+    libxinerama-dev \
+    libxrandr-dev \
+    libxss-dev \
+    libxxf86vm-dev \
+    libsdl2-dev \
+    libsdl2-image-dev \
+    libsdl2-mixer-dev \
+    libsdl2-ttf-dev \
+    libfreetype6-dev \
+    libportmidi-dev \
+    libjpeg-dev \
+    ninja-build \
+    ffmpeg
+
+# Clean up
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set Bash as the default shell
+SHELL ["/bin/bash", "-c"]
+# Install Python 3.10
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
+    add-apt-repository ppa:deadsnakes/ppa && \
+    apt-get update && \
+    apt-get install -y python3.10 python3.10-dev python3.10-distutils && \
+    update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.10 1 && \
+    update-alternatives --set python3 /usr/bin/python3.10
+
+# Install pip for Python 3.10
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python3.10
+
+# Install Habitat-Sim
+RUN git clone https://github.com/facebookresearch/habitat-sim.git
+WORKDIR /habitat-sim
+
+# Patch dependencies.cmake to force MAGNUM_TARGET_EGL to OFF
+# This ensures that when we build in Headless mode, it picks GLX instead of EGL
+RUN sed -i 's/set(MAGNUM_TARGET_EGL .*/set(MAGNUM_TARGET_EGL OFF CACHE BOOL "" FORCE)/' src/cmake/dependencies.cmake
+
+# Build with TARGET_HEADLESS=ON (Default).
+# Since EGL is disabled above, this forces the build to use Windowless GLX.
+RUN CMAKE_ARGS="-DCMAKE_POLICY_VERSION_MINIMUM=3.5 -DTARGET_HEADLESS=ON" pip install . -v
+
+# Install Habitat-Lab
+WORKDIR /
+RUN git clone https://github.com/facebookresearch/habitat-lab.git
+WORKDIR /habitat-lab
+RUN pip install -e habitat-lab
+RUN pip install pybullet==3.0.4 pygame==2.1.2
+
+
+WORKDIR /app
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.humble
+++ b/docker/Dockerfile.humble
@@ -124,11 +124,16 @@ RUN colcon build \
     --parallel-workers $(nproc) \
     --packages-skip-build-finished
 
-# Set up ROS 2 environment
-RUN echo "source /ros2_humble/install/setup.bash" >> /root/.bashrc
-
 RUN pip3 install --ignore-installed "coverage>=7.2,<7.4" "numba==0.58.1"
 RUN apt-get update && apt-get install ros-humble-cv-bridge -y
+
+# Set up ROS 2 environment
+RUN echo "source /ros2_humble/install/setup.bash" >> /root/.bashrc
+RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc
+
+# Create symlink so 'python' points to 'python3'
+RUN ln -sf /usr/bin/python3 /usr/bin/python
+
 # Set environment variables for ROS 2
 ENV ROS_DISTRO=humble
 ENV AMENT_PREFIX_PATH=/ros2_humble/install

--- a/docker/Dockerfile.humble
+++ b/docker/Dockerfile.humble
@@ -1,0 +1,143 @@
+# Build from the habitat-data-collector image that contains CUDA, Python 3.10, Habitat-Sim, and Habitat-Lab
+FROM habitat-data-collector:latest
+
+# Prevent interactive prompts during package installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set locale
+RUN apt-get update && apt-get install -y locales && \
+    locale-gen en_US en_US.UTF-8 && \
+    update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LC_ALL=en_US.UTF-8
+
+# Add ROS 2 apt repository
+RUN apt-get update && apt-get install -y \
+    software-properties-common \
+    curl \
+    gnupg \
+    lsb-release \
+    && curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | tee /etc/apt/sources.list.d/ros2.list > /dev/null \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install dependencies for building ROS 2 from source
+RUN apt-get update && apt-get install -y \
+    wget \
+    unzip \
+    python3-pip \
+    python3-pytest-cov \
+    python3-flake8-docstrings \
+    python3-setuptools \
+    python3-vcstool \
+    python3-rosdep \
+    python3-colcon-common-extensions \
+    libasio-dev \
+    libtinyxml2-dev \
+    libcunit1-dev \
+    liblog4cxx-dev \
+    libyaml-cpp-dev \
+    libeigen3-dev \
+    libopencv-dev \
+    libssl-dev \
+    libacl1-dev \
+    libsqlite3-dev \
+    libxml2-dev \
+    libxslt1-dev \
+    libbullet-dev \
+    libconsole-bridge-dev \
+    liblttng-ust-dev \
+    lttng-tools \
+    python3-lttng \
+    python3-babeltrace \
+    libbenchmark-dev \
+    pybind11-dev \
+    python3-pybind11 \
+    qtbase5-dev \
+    libqt5core5a \
+    libqt5gui5 \
+    libqt5opengl5 \
+    libqt5widgets5 \
+    libspdlog-dev \
+    graphviz \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install additional Python dependencies for ROS 2
+# Using --ignore-installed to handle system packages that can't be uninstalled
+# Pinning empy<4 as ROS 2 Humble requires empy 3.x
+# Pinning setuptools<71 to maintain compatibility with ROS 2 Humble's build system
+RUN pip3 install --ignore-installed \
+    "setuptools==70.0.0" \
+    argcomplete \
+    flake8-blind-except \
+    flake8-builtins \
+    flake8-class-newline \
+    flake8-comprehensions \
+    flake8-deprecated \
+    flake8-import-order \
+    flake8-quotes \
+    pytest-repeat \
+    pytest-rerunfailures \
+    pytest \
+    lark \
+    catkin_pkg \
+    "empy<4" \
+    netifaces \
+    pyparsing \
+    pyyaml
+
+# Create ROS 2 workspace
+RUN mkdir -p /ros2_humble/src
+WORKDIR /ros2_humble
+
+# Download ROS 2 Humble source code
+# Using retry logic to handle transient GitHub failures
+RUN wget https://raw.githubusercontent.com/ros2/ros2/humble/ros2.repos && \
+    for i in 1 2 3 4 5; do \
+        vcs import src < ros2.repos && break || { echo "Retry $i failed, waiting 30s..."; sleep 30; }; \
+    done
+
+# Initialize rosdep
+RUN rosdep init || true && \
+    rosdep update
+
+# Install dependencies using rosdep
+RUN apt-get update && \
+    rosdep install --from-paths src --ignore-src -y --skip-keys "fastcdr rti-connext-dds-6.0.1 urdfdom_headers python3-catkin-pkg-modules python3-rosdistro-modules" || true && \
+    rm -rf /var/lib/apt/lists/*
+
+# Build ROS 2 Humble (desktop variant)
+# Using parallel jobs based on available memory to avoid OOM
+# Pre-download OGRE to avoid transient GitHub download failures
+RUN mkdir -p /ros2_humble/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src && \
+    cd /ros2_humble/build/rviz_ogre_vendor/ogre-v1.12.1-prefix/src && \
+    for i in 1 2 3 4 5; do \
+        wget -q https://github.com/OGRECave/ogre/archive/v1.12.1.zip && break || sleep 15; \
+    done && \
+    unzip -q v1.12.1.zip && \
+    rm v1.12.1.zip
+
+RUN colcon build \
+    --symlink-install \
+    --cmake-args -DCMAKE_BUILD_TYPE=Release \
+    --parallel-workers $(nproc) \
+    --packages-skip-build-finished
+
+# Set up ROS 2 environment
+RUN echo "source /ros2_humble/install/setup.bash" >> /root/.bashrc
+
+RUN pip3 install --ignore-installed "coverage>=7.2,<7.4" "numba==0.58.1"
+RUN apt-get update && apt-get install ros-humble-cv-bridge -y
+# Set environment variables for ROS 2
+ENV ROS_DISTRO=humble
+ENV AMENT_PREFIX_PATH=/ros2_humble/install
+ENV CMAKE_PREFIX_PATH=/ros2_humble/install
+ENV COLCON_PREFIX_PATH=/ros2_humble/install
+ENV LD_LIBRARY_PATH=/ros2_humble/install/lib:${LD_LIBRARY_PATH:-}
+ENV PATH=/ros2_humble/install/bin:${PATH:-}
+ENV PYTHONPATH=/ros2_humble/install/lib/python3.10/site-packages:${PYTHONPATH:-}
+ENV ROS_PYTHON_VERSION=3
+
+WORKDIR /app
+CMD ["/bin/bash"]

--- a/docker/Dockerfile.humble
+++ b/docker/Dockerfile.humble
@@ -124,6 +124,8 @@ RUN colcon build \
     --parallel-workers $(nproc) \
     --packages-skip-build-finished
 
+# Uninstall numpy to remove the version from the base image (e.g. 2.x) before installing the version required by numba
+RUN pip3 uninstall -y numpy || true
 RUN pip3 install --ignore-installed "coverage>=7.2,<7.4" "numba==0.58.1"
 RUN apt-get update && apt-get install ros-humble-cv-bridge -y
 

--- a/docker/compose.humble.yml
+++ b/docker/compose.humble.yml
@@ -1,0 +1,24 @@
+services:
+  habitat-data-collector-ros:
+    build:
+      context: .
+      dockerfile: Dockerfile.humble
+    image: habitat-data-collector-ros
+    network_mode: host
+    volumes:
+      - ../:/app
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - $HOME/.Xauthority:/root/.Xauthority
+      - /dev:/dev
+    environment:
+      - DISPLAY=${DISPLAY}
+      - NVIDIA_DRIVER_CAPABILITIES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu, graphics, utility, compute]
+    stdin_open: true
+    tty: true

--- a/docker/compose.yml
+++ b/docker/compose.yml
@@ -1,0 +1,24 @@
+services:
+  habitat-data-collector:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: habitat-data-collector
+    network_mode: host
+    volumes:
+      - ../:/app
+      - /tmp/.X11-unix:/tmp/.X11-unix
+      - $HOME/.Xauthority:/root/.Xauthority
+      - /dev:/dev
+    environment:
+      - DISPLAY=${DISPLAY}
+      - NVIDIA_DRIVER_CAPABILITIES=all
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu, graphics, utility, compute]
+    stdin_open: true
+    tty: true

--- a/habitat_data_collector/utils/habitat_utils.py
+++ b/habitat_data_collector/utils/habitat_utils.py
@@ -645,8 +645,8 @@ def save_scene_object_info(scene, scene_dir):
             
             # Get bounding box (AABB) details: center and size
             bbox = {
-                'center': [obj.aabb.center().x, obj.aabb.center().y, obj.aabb.center().z],  # Convert ndarray to list
-                'sizes': [obj.aabb.size().x, obj.aabb.size().y, obj.aabb.size().z]     # Convert ndarray to list
+                'center': obj.aabb.center.tolist(),  # Convert ndarray to list
+                'sizes': obj.aabb.sizes.tolist()     # Convert ndarray to list
             }
             
             # Add the bbox to the corresponding class
@@ -768,8 +768,8 @@ def get_bounding_boxes_for_category(sim, category_name):
         obj_category_name = obj.category.name() if obj.category else None
         if obj_category_name == category_name:
             # 提取包围盒的中心和大小信息
-            aabb_center = obj.aabb.center()
-            aabb_size = obj.aabb.size()
+            aabb_center = obj.aabb.center
+            aabb_size = obj.aabb.sizes
             bounding_box_info = {
                 "Object_ID": obj.id,
                 "Category": category_name,

--- a/habitat_data_collector/utils/habitat_utils.py
+++ b/habitat_data_collector/utils/habitat_utils.py
@@ -645,8 +645,8 @@ def save_scene_object_info(scene, scene_dir):
             
             # Get bounding box (AABB) details: center and size
             bbox = {
-                'center': obj.aabb.center.tolist(),  # Convert ndarray to list
-                'sizes': obj.aabb.sizes.tolist()     # Convert ndarray to list
+                'center': [obj.aabb.center().x, obj.aabb.center().y, obj.aabb.center().z],  # Convert ndarray to list
+                'sizes': [obj.aabb.size().x, obj.aabb.size().y, obj.aabb.size().z]     # Convert ndarray to list
             }
             
             # Add the bbox to the corresponding class
@@ -768,8 +768,8 @@ def get_bounding_boxes_for_category(sim, category_name):
         obj_category_name = obj.category.name() if obj.category else None
         if obj_category_name == category_name:
             # 提取包围盒的中心和大小信息
-            aabb_center = obj.aabb.center
-            aabb_size = obj.aabb.sizes
+            aabb_center = obj.aabb.center()
+            aabb_size = obj.aabb.size()
             bounding_box_info = {
                 "Object_ID": obj.id,
                 "Category": category_name,


### PR DESCRIPTION
This PR adds the Docker setup mentioned in https://github.com/Eku127/habitat-data-collector/issues/14.

The Docker setup is split into two parts. If you don't need ROS, you can just use the base Dockerfile, but if you also want ROS inside the container, you can use `compose.humble.yml` to build an image that installs ROS humble from source.

Getting CUDA, habitat-sim, habitat-lab, ROS, etc. to work in the same environment is somewhat involved, hence why the Dockerfiles may look a bit messy. If you have suggestions for how they can be tidied up, I'm happy to hear them :)

I've tested the build on a machine with an RTX 4070ti ( Driver Version: 575.57.08, CUDA Version: 12.9), and I will try to test it on a different machine as soon as I have some time.